### PR TITLE
removed fortran from testing scripts

### DIFF
--- a/ci/install-apt-pkgs.sh
+++ b/ci/install-apt-pkgs.sh
@@ -1,7 +1,6 @@
 set -ex
 
 apt install -y \
-    gfortran \
     mpich \
     libmpich-dev \
     libhdf5-serial-dev \

--- a/ci/moab-install.sh
+++ b/ci/moab-install.sh
@@ -13,7 +13,10 @@ cd $HOME
 mkdir MOAB && cd MOAB
 git clone -b $MOAB_BRANCH $MOAB_REPO
 mkdir build && cd build
-cmake ../moab -DENABLE_HDF5=ON -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR -DENABLE_BLASLAPACK=OFF
+cmake ../moab -DENABLE_HDF5=ON \
+              -DENABLE_FORTRAN=OFF \
+              -DENABLE_BLASLAPACK=OFF \
+              -DCMAKE_INSTALL_PREFIX=$MOAB_INSTALL_DIR
 make -j 3 && make -j 3 test install
 cmake ../moab -DBUILD_SHARED_LIBS=OFF
 make -j 3 install


### PR DESCRIPTION
As discussing in #9 this is an update to the testing scripts which removes fortran dependency

I am sure I will need to add some additional parts here but I'm keen to see what errors are raised with this initial attempt