### PR TITLE
triggering CI on a PR as well as push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Double Down CI
 
-on: [push]
+on:
+  push:
+    branches:
+    - main
+  pull_request:    
+    branches:
+    - main
 
 env:
   BUILD_TYPE: Release


### PR DESCRIPTION
Perhaps github actions should run on the PR event as well as the push event that it currently runs on