### PR TITLE
Refactor initialization

### DIFF
--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -103,12 +103,29 @@ moab::ErrorCode RayTracingInterface::init(std::string filename)
   // create an Embree geometry instance for each surface
   for (moab::Range::iterator i = vols.begin(); i != vols.end(); i++) {
     moab::EntityHandle vol = *i;
-
     createBVH(vol);
-
   } // end volume loop
 
   return moab::MB_SUCCESS;
+}
+
+moab::ErrorCode
+RayTracingInterface::createVolumeBVH(moab::EntityHandle vol) {
+
+  moab::ErrorCode rval;
+
+
+  return moab::MB_SUCCESS;
+}
+
+
+moab::ErrorCode
+RayTracingInterface::createSurfaceBVH(moab::EntityHandle surf) {
+
+  moab::ErrorCode rval;
+
+
+  return MB_SUCCESS;
 }
 
 moab::ErrorCode RayTracingInterface::createBVH(moab::EntityHandle vol) {
@@ -187,7 +204,7 @@ moab::ErrorCode RayTracingInterface::createBVH(moab::EntityHandle vol) {
     }
 
     rtcSetGeometryBuildQuality(geom_0,RTC_BUILD_QUALITY_HIGH);
-    rtcSetGeometryUserPrimitiveCount(geom_0,num_tris);
+    rtcSetGeometryUserPrimitiveCount(geom_0, num_tris);
     rtcSetGeometryTimeStepCount(geom_0,1);
 
     DblTri* buff_ptr = emtris.get() + buffer_start;

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -134,25 +134,6 @@ RayTracingInterface::allocateTriangleBuffer(moab::EntityHandle vol) {
   return MB_SUCCESS;
 }
 
-moab::ErrorCode
-RayTracingInterface::createVolumeBVH(moab::EntityHandle vol) {
-
-  moab::ErrorCode rval;
-
-
-  return moab::MB_SUCCESS;
-}
-
-
-moab::ErrorCode
-RayTracingInterface::createSurfaceBVH(moab::EntityHandle surf) {
-
-  moab::ErrorCode rval;
-
-
-  return MB_SUCCESS;
-}
-
 moab::ErrorCode RayTracingInterface::createBVH(moab::EntityHandle vol) {
 
   if (GTT->dimension(vol) != 3) {

--- a/src/RTI.hpp
+++ b/src/RTI.hpp
@@ -42,7 +42,7 @@ class RayTracingInterface {
     }
 
     std::pair<int, std::shared_ptr<DblTri>> retrieve_buffer(moab::EntityHandle vol) {
-      return storage_[vol];
+      return storage_.at(vol);
     }
 
     void free_storage(moab::EntityHandle vol) {

--- a/src/RTI.hpp
+++ b/src/RTI.hpp
@@ -132,6 +132,10 @@ class RayTracingInterface {
   moab::ErrorCode get_vols(moab::Range& vols);
   void fire(moab::EntityHandle vol, RTCDRayHit &rayhit);
 
+  //! \brief Allocates space for triangle reference information for the volume
+  moab::ErrorCode
+  allocateTriangleBuffer(moab::EntityHandle vol);
+
   moab::ErrorCode
   createVolumeBVH(moab::EntityHandle vol);
 

--- a/src/RTI.hpp
+++ b/src/RTI.hpp
@@ -133,6 +133,12 @@ class RayTracingInterface {
   void fire(moab::EntityHandle vol, RTCDRayHit &rayhit);
 
   moab::ErrorCode
+  createVolumeBVH(moab::EntityHandle vol);
+
+  moab::ErrorCode
+  createSurfaceBVH(moab::EntityHandle surf);
+
+  moab::ErrorCode
   createBVH(moab::EntityHandle vol);
 
   void
@@ -188,7 +194,7 @@ class RayTracingInterface {
   std::unordered_map<moab::EntityHandle, std::pair<unsigned int, unsigned int>> em_geom_id_map;
   std::unordered_map<moab::EntityHandle, std::pair<RTCGeometry, RTCGeometry>> em_geom_map;
   std::unordered_map<moab::EntityHandle, RTCScene> scene_map;
-  std::unordered_map<moab::EntityHandle, std::vector<std::shared_ptr<DblTri>>> tri_ref_storage;
+
   std::vector<RTCScene> scenes;
   moab::EntityHandle sceneOffset;
   std::unordered_map<moab::EntityHandle, Node*> root_map;
@@ -196,7 +202,6 @@ class RayTracingInterface {
   // a couple values we never touch really
   double numerical_precision {1E-3};
   double overlap_thickness {0.0};
-
 
   RTCDevice g_device {nullptr};
 };

--- a/src/RTI.hpp
+++ b/src/RTI.hpp
@@ -20,28 +20,21 @@ class Node;
 class RayTracingInterface {
 
   class DblTriStorage {
-  private:
-    std::unordered_map<moab::EntityHandle, std::pair<int, std::shared_ptr<DblTri>>> storage_;
-
   public:
     bool is_storing(moab::EntityHandle vol) {
-      return storage_.count(vol);
+      return storage_.find(vol) != storage_.end();
     }
 
-    bool is_storing(std::shared_ptr<DblTri> ptr) {
-      for (auto it : storage_) {
-        if (it.second.second == ptr) return true;
-      }
-      return false;
+    void store(moab::EntityHandle vol, std::vector<DblTri>&& buffer) {
+      if (storage_.find(vol) != storage_.end()) { return; }
+      storage_[vol] = buffer;
     }
 
-    void store(moab::EntityHandle vol, int size, std::shared_ptr<DblTri> ptr) {
-      if (!is_storing(ptr)) {
-        storage_[vol] = {size, ptr};
-      }
+    std::vector<DblTri>& retrieve_buffer(moab::EntityHandle vol) {
+      return storage_.at(vol);
     }
 
-    std::pair<int, std::shared_ptr<DblTri>> retrieve_buffer(moab::EntityHandle vol) {
+    const std::vector<DblTri>& retrieve_buffer(moab::EntityHandle vol) const {
       return storage_.at(vol);
     }
 
@@ -52,6 +45,9 @@ class RayTracingInterface {
     void clear() {
       storage_.clear();
     }
+
+  private:
+    std::unordered_map<moab::EntityHandle, std::vector<DblTri>> storage_;
 
   };
 

--- a/src/RTI.hpp
+++ b/src/RTI.hpp
@@ -21,28 +21,34 @@ class RayTracingInterface {
 
   class DblTriStorage {
   public:
-    bool is_storing(moab::EntityHandle vol) {
+    bool is_storing(moab::EntityHandle vol)
+    {
       return storage_.find(vol) != storage_.end();
     }
 
-    void store(moab::EntityHandle vol, std::vector<DblTri>&& buffer) {
+    void store(moab::EntityHandle vol, std::vector<DblTri>&& buffer)
+    {
       if (storage_.find(vol) != storage_.end()) { return; }
       storage_[vol] = buffer;
     }
 
-    std::vector<DblTri>& retrieve_buffer(moab::EntityHandle vol) {
+    std::vector<DblTri>& retrieve_buffer(moab::EntityHandle vol)
+    {
       return storage_.at(vol);
     }
 
-    const std::vector<DblTri>& retrieve_buffer(moab::EntityHandle vol) const {
+    const std::vector<DblTri>& retrieve_buffer(moab::EntityHandle vol) const
+    {
       return storage_.at(vol);
     }
 
-    void free_storage(moab::EntityHandle vol) {
+    void free_storage(moab::EntityHandle vol)
+    {
       if (is_storing(vol)) storage_.erase(vol);
     }
 
-    void clear() {
+    void clear()
+    {
       storage_.clear();
     }
 

--- a/test/test_build.cpp
+++ b/test/test_build.cpp
@@ -7,7 +7,6 @@
 
 
 int main() {
-
   // create new MOAB instance
   moab::Interface* MBI = new moab::Core();
 
@@ -39,29 +38,8 @@ int main() {
   if (dist == 0.0) { return 1; }
   if (surf == 0) { return 1; }
 
-
   // tear down the BVH for this volume
   RTI->deleteBVH(sphere_vol);
-
-  // rebuild the BVH for this volume
-  RTI->createBVH(sphere_vol);
-
-  // ray fire again to make sure this works
-  surf = 0;
-  RTI->ray_fire(sphere_vol, org, dir, surf, dist);
-
-  if (dist == 0.0) { return 1; }
-  if (surf == 0) { return 1; }
-
-  // delete the surface tree
-  RTI->deleteBVH(surf);
-
-  // ray fire again, expect to hit nothing
-  surf = 0;
-  RTI->ray_fire(sphere_vol, org, dir, surf, dist);
-
-  if (dist < 1000.0) { return 1; }
-  if (surf != 0) { return 1; }
 
   // rebuild the BVH for this volume
   RTI->createBVH(sphere_vol);


### PR DESCRIPTION
This cleans up the `RTI::init` method a bit by separating triangle buffer allocations for volumes from the BVH creation. The internal buffer storage type is now a `std::vector`, giving us a little more robustness in memory management of the DblTri instances.

It also closes the book on being able to create and delete BVH structures by surface -- it's very difficult to do this due to the interdependence of the triangle buffers, RTCGeometry user data, and geomIDs.