### PR TITLE
Updating CI apt package installations.

### DIFF
--- a/ci/install-apt-pkgs.sh
+++ b/ci/install-apt-pkgs.sh
@@ -6,7 +6,4 @@ apt install -y \
     libhdf5-serial-dev \
     libhdf5-mpich-dev \
     libeigen3-dev \
-    libtbb-dev \
-    freeglut3-dev \
-    libglfw3 \
-    libglfw3-dev
+    libtbb-dev


### PR DESCRIPTION
Some of the apt packages related to video drivers were being installed as part of the CI workflow and are no longer supported in the new version of Ubuntu on GHA. They weren't being used anyways since we're installing Embree without tutorials (and their demonstration renderer) enabled.