### PR TITLE
Setting bounding box expansion dynamically based on volume size.

### DIFF
--- a/include/double-down/RTI.hpp
+++ b/include/double-down/RTI.hpp
@@ -328,6 +328,8 @@ class RayTracingInterface {
   std::shared_ptr<moab::GeomTopoTool> GTT; //!< MOAB GeomTopoTool instance.
   std::shared_ptr<MBDirectAccess> mdam; //!< MBDirectAccess instance.
   DblTriStorage buffer_storage; //!< Per-volume storage for DblTri instances
+  std::unordered_map<RTCGeometry, UserData> data_ptr_map; //!< mapping of geometry instance to
+
   std::unordered_map<moab::EntityHandle, RTCScene> scene_map; //!< Mapping from MOAB volume EntityHandle's to Embree Scenes.
   double numerical_precision {1E-3}; //!< Numerical precision for triangle intersections.
   double overlap_thickness {0.0}; //!< Allowed overlap thickness for self-intersecting volumes.

--- a/include/double-down/primitives.hpp
+++ b/include/double-down/primitives.hpp
@@ -22,13 +22,18 @@ struct DblTri {
   int sense;
 };
 
+/*! Structure for linking primitive data with surfaces */
+struct UserData {
+    double bump; //!< bounding box bump value for this set of triangles
+    DblTri* tri_ptr; //!< Set of triangles in the buffer
+};
+
 //! \brief Function returning the extended bounds of a double precision MOAB triangle
-inline RTCBounds DblTriBounds(MBDirectAccess* mdam, moab::EntityHandle tri_handle) {
+inline RTCBounds DblTriBounds(MBDirectAccess* mdam,
+                              moab::EntityHandle tri_handle,
+                              double bump_val = 5e-03) {
 
   std::array<Vec3da, 3> coords = mdam->get_coords(tri_handle);
-
-  // amount by which to extend the bounding box of the triangle
-  double bump_val = 5e-03;
 
   RTCBounds bounds_o;
   bounds_o.lower_x = std::min(coords[0][0],std::min(coords[1][0],coords[2][0]));

--- a/src/MOABRay.cpp
+++ b/src/MOABRay.cpp
@@ -67,7 +67,7 @@ void count_hits(MBRayHitAccumulate* rayhit) {
 
 void MBDblTriIntersectFunc(RTCIntersectFunctionNArguments* args) {
 
-  void* tris_i = args->geometryUserPtr;
+  const UserData* user_data = (const UserData*) args->geometryUserPtr;
   size_t item = args->primID;
   MBRayHit* rayhit = (MBRayHit*)args->rayhit;
   MBRay& ray = rayhit->ray;
@@ -83,7 +83,7 @@ void MBDblTriIntersectFunc(RTCIntersectFunctionNArguments* args) {
     return;
   }
 
-  const DblTri* tris = (const DblTri*) tris_i;
+  const DblTri* tris = (const DblTri*) user_data->tri_ptr;
   const DblTri& this_tri = tris[item];
 
   hit.prim_handle = this_tri.handle;

--- a/src/primitives.cpp
+++ b/src/primitives.cpp
@@ -22,12 +22,12 @@ void intersectionFilter(void* ptr, RTCDRayHit &rayhit)
 void DblTriBounds(const RTCBoundsFunctionArguments* args)
 {
   // get the array of DblTri's stored on the geometry
-  void* tris_i = args->geometryUserPtr;
+  const UserData* user_data = (const UserData*) args->geometryUserPtr;
   // referencde to the returned triangle bounds
   RTCBounds& bounds_o = *args->bounds_o;
 
   // convert the void user data pointer to the DblTri pointer
-  const DblTri* tris = (const DblTri*) tris_i;
+  const DblTri* tris = (const DblTri*) user_data->tri_ptr;
   // select the DblTri in question based on the primitive ID
   const DblTri& this_tri = tris[args->primID];
 
@@ -35,14 +35,14 @@ void DblTriBounds(const RTCBoundsFunctionArguments* args)
   MBDirectAccess* mdam = (MBDirectAccess*) this_tri.mdam;
 
   // compute the bounding box using the direct access manager and the triangle's handle
-  bounds_o = DblTriBounds(mdam, this_tri.handle);
+  bounds_o = DblTriBounds(mdam, this_tri.handle, user_data->bump);
 }
 
 void DblTriIntersectFunc(RTCIntersectFunctionNArguments* args) {
   // get the array of DblTri's stored on the geometry
-  void* tris_i = args->geometryUserPtr;
+  const UserData* user_data = (const UserData*) args->geometryUserPtr;
   // convert the void user data pointer to the DblTri pointer
-  const DblTri* tris = (const DblTri*) tris_i;
+  const DblTri* tris = (const DblTri*) user_data->tri_ptr;
   // select the DblTri in question based on the primitive ID
   const DblTri& this_tri = tris[args->primID];
 
@@ -56,7 +56,6 @@ void DblTriIntersectFunc(RTCIntersectFunctionNArguments* args) {
 
   // get the triangle coordinates from the direct access manager
   std::array<moab::CartVect, 3> coords = mdam->get_mb_coords(this_tri.handle);
-
 
   double dist; // local variable for the distance to the triangle intersection
   // convert the ray origin and directory to MOAB CartVect
@@ -101,9 +100,9 @@ void DblTriIntersectFunc(RTCIntersectFunctionNArguments* args) {
 
 void DblTriOccludedFunc(RTCOccludedFunctionNArguments* args) {
   // get the array of DblTri's stored on the geometry
-  void* tris_i = args->geometryUserPtr;
+  const UserData* user_data = (const UserData*) args->geometryUserPtr;
   // convert the void user data pointer to the DblTri pointer
-  const DblTri* tris = (const DblTri*) tris_i;
+  const DblTri* tris = (const DblTri*) user_data->tri_ptr;
   // select the DblTri in question based on the primitive ID
   const DblTri& this_tri = tris[args->primID];
 
@@ -140,9 +139,9 @@ bool DblTriPointQueryFunc(RTCPointQueryFunctionArguments* args) {
   RTCGeometry g = rtcGetGeometry(*(RTCScene*)args->userPtr, args->geomID);
 
   // get the array of DblTri's stored on the geometry
-  void* tris_i = rtcGetGeometryUserData(g);
+  const UserData* user_data = (const UserData*) rtcGetGeometryUserData(g);
   // convert the void user data pointer to the DblTri pointer
-  const DblTri* tris = (const DblTri*) tris_i;
+  const DblTri* tris = (const DblTri*) user_data->tri_ptr;
   // select the DblTri in question based on the primitive ID
   const DblTri& this_tri = tris[args->primID];
   // compute the distance to the nearest point on the triangle

--- a/test/test_rf.cpp
+++ b/test/test_rf.cpp
@@ -44,6 +44,7 @@ int main() {
   RTI->get_bbox(sphere_vol, llc, urc);
 
   double sphere_bound = 10.0;
+  sphere_bound -= 1e-04; // make allowance for faceting tolerance
   for (int i = 0; i < 3; i++) {
     if (llc[i] >= -sphere_bound) { return 1; }
     if (urc[i] <= sphere_bound) { return 1;}


### PR DESCRIPTION
This PR adjusts the amount bounding boxes are expanded based on the volume size. This library is designed to assist with Monte Carlo radiation transport where rays are always fired from inside a volume, which allows us to calculate an upper limit on the farthest intersection distance. The conservative estimate of the longest distance used here is longest diagonal of the volume's axis-aligned bounding box.

This value is computed using the following equation:

![image](https://user-images.githubusercontent.com/4563941/135919214-810d15a9-2071-45ec-9cd7-a504a6d6f3e1.png)

Where `dx`, `dy`, and `dz` are the distances along the x, y, and z axes respectively and `FLT_DIGITS` is the number of floating point digits on the machine in use (i.e. an upper limit on how much the ray direction is perturbed in conversion from double to single precision).