### PR TITLE
Adding method to report the git sha used to compile dd.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,18 @@ install( TARGETS dd
 install(EXPORT ddTargets DESTINATION "${DD_CMAKE_CONFIG_LOCATION}")
 export( TARGETS dd FILE "ddTargets.cmake" )
 
+find_package(Git)
+# Set git SHA1 hash as a compile definition
+if(GIT_FOUND)
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  RESULT_VARIABLE GIT_SHA1_SUCCESS
+                  OUTPUT_VARIABLE GIT_SHA1
+                  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(GIT_SHA1_SUCCESS EQUAL 0)
+    target_compile_definitions(dd PRIVATE -DGIT_SHA1="${GIT_SHA1}")
+  endif()
+endif()
 
 # install headers
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/double-down/RTI.hpp" DESTINATION "${DD_INCLUDE_INSTALL_LOCATION}")

--- a/include/double-down/RTI.hpp
+++ b/include/double-down/RTI.hpp
@@ -89,6 +89,9 @@ class RayTracingInterface {
   //! \param filename Path to the mesh file to load.
   moab::ErrorCode load_file(std::string filename);
 
+  //! \brief Returns the git sha used to compile the executable (if available).
+  std::string git_sha() const;
+
   //! \brief Initialize the RTI, building acceleration datastructures and internal storage.
   //! Assumes that the MOAB file is already open.
   moab::ErrorCode init();

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -62,7 +62,7 @@ std::string RayTracingInterface::git_sha() const {
 #ifdef GIT_SHA1
   return GIT_SHA1;
 #else
-  return "";
+  return "unavailable";
 #endif
 }
 

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -58,6 +58,14 @@ moab::ErrorCode RayTracingInterface::load_file(std::string filename) {
   return rval;
 }
 
+std::string RayTracingInterface::git_sha() const {
+#ifdef GIT_SHA1
+  return GIT_SHA1;
+#else
+  return "";
+#endif
+}
+
 moab::ErrorCode
 RayTracingInterface::get_obb(moab::EntityHandle volume,
                              double center[3],

--- a/test/test_rf.cpp
+++ b/test/test_rf.cpp
@@ -21,6 +21,8 @@ int main() {
   rval = RTI->init();
   MB_CHK_SET_ERR(rval, "Failed to initialize the RTI.");
 
+  std::cout << "GIT SHA: " << RTI->git_sha() << std::endl;
+
   moab::Range vols;
   rval = RTI->get_vols(vols);
   MB_CHK_SET_ERR(rval, "Failed to get volumes from the RTI.");

--- a/test/test_rf.cpp
+++ b/test/test_rf.cpp
@@ -21,8 +21,6 @@ int main() {
   rval = RTI->init();
   MB_CHK_SET_ERR(rval, "Failed to initialize the RTI.");
 
-  std::cout << "GIT SHA: " << RTI->git_sha() << std::endl;
-
   moab::Range vols;
   rval = RTI->get_vols(vols);
   MB_CHK_SET_ERR(rval, "Failed to get volumes from the RTI.");

--- a/tools/closest_to_location.cpp
+++ b/tools/closest_to_location.cpp
@@ -25,6 +25,8 @@ int main(int argc, char** argv) {
   // create new ray tracing interface
   std::unique_ptr<RayTracingInterface> RTI{new RayTracingInterface()};
 
+  std::cout << "Double Down Git SHA: " << RTI->git_sha() << std::endl;
+
   moab::ErrorCode rval;
   rval = RTI->load_file(po.getReqArg<std::string>("filename").c_str());
   MB_CHK_SET_ERR(rval, "Failed to load test file");

--- a/tools/ray_fire.cpp
+++ b/tools/ray_fire.cpp
@@ -28,11 +28,16 @@ int main(int argc, char** argv) {
 
   po.parseCommandLine(argc, argv);
 
+
+
+  std::shared_ptr<RayTracingInterface> RTI{new RayTracingInterface()};
+
+  std::cout << "Double Down Git SHA: " << RTI->git_sha() << std::endl;
+
 #ifdef __AVX2__
   std::cout << "AVX2 Enabled" << std::endl;
 #endif
 
-  std::shared_ptr<RayTracingInterface> RTI{new RayTracingInterface()};
 
   moab::ErrorCode rval;
   rval = RTI->load_file(filename);


### PR DESCRIPTION
Adding this method so the version used to compile double-down can be reported in the compiled tools and downstream applications.