### PR TITLE
Including array header in relevant files

### DIFF
--- a/include/double-down/MOABDirectAccess.h
+++ b/include/double-down/MOABDirectAccess.h
@@ -1,6 +1,7 @@
 #ifndef _MBDIRECTACCESS_
 #define _MBDIRECTACCESS_
 
+#include <array>
 #include <memory>
 
 // MOAB

--- a/include/double-down/primitives.hpp
+++ b/include/double-down/primitives.hpp
@@ -2,6 +2,8 @@
 #ifndef DD_PRIMITIVES_H
 #define DD_PRIMITIVES_H
 
+#include <array>
+
 // Embree
 #include "embree3/rtcore.h"
 


### PR DESCRIPTION
The include for `std::array` was missing in these headers and cause the build to break for gcc12 on arch-linux. This PR includes the headers properly.