### PR TITLE
Support Embree4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Embree Build
       shell: bash
-      run: $GITHUB_WORKSPACE/ci/embree-install.sh ${embree_version}
+      run: $GITHUB_WORKSPACE/ci/embree-install.sh ${{ matrix.embree_version }}
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ env:
   DISPLAY: 99.0
 
 jobs:
-  strategty:
-    matrix:
-      embree_version: ['3.6.1', '4.0.0']
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        embree_version: ['3.6.1', '4.0.0']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ env:
   DISPLAY: 99.0
 
 jobs:
+  strategty:
+    matrix:
+      embree_version: ['3.6.1', '4.0.0']
   build:
     runs-on: ubuntu-latest
 
@@ -46,7 +49,7 @@ jobs:
 
     - name: Embree Build
       shell: bash
-      run: $GITHUB_WORKSPACE/ci/embree-install.sh
+      run: $GITHUB_WORKSPACE/ci/embree-install.sh ${embree_version}
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        embree_version: ['3.6.1', '4.0.0']
+        embree_version: ['3.6.1', '4.0.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,12 @@ MESSAGE ( STATUS "MOAB_INCLUDE_DIRS is " ${MOAB_INCLUDE_DIRS} )
 INCLUDE_DIRECTORIES( ${MOAB_INCLUDE_DIRS} )
 
 # Embree
+# this series of calls is needed to support the way that Embree indicates
+# compatible versions in 3 and 4 (version 4 does it correctly, but 3 does not)
 FIND_PACKAGE(embree 3.6.1 HINTS ${EMBREE_DIR} QUIET)
-
 if (NOT ${embree_FOUND})
 FIND_PACKAGE (embree REQUIRED HINTS ${EMBREE_DIR})
 endif()
-
 
 if (NOT ${EMBREE_VERSION} VERSION_GREATER 3.6.0)
   message(FATAL_ERROR "Double-down requires Embree v3.6.1 or higher.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,18 @@ MESSAGE ( STATUS "MOAB_INCLUDE_DIRS is " ${MOAB_INCLUDE_DIRS} )
 INCLUDE_DIRECTORIES( ${MOAB_INCLUDE_DIRS} )
 
 # Embree
-FIND_PACKAGE (embree 3.6.1 REQUIRED HINTS ${EMBREE_DIR})
+FIND_PACKAGE(embree 3.6.1 HINTS ${EMBREE_DIR} QUIET)
+
+if (NOT ${embree_FOUND})
+FIND_PACKAGE (embree REQUIRED HINTS ${EMBREE_DIR})
+endif()
+
 
 if (NOT ${EMBREE_VERSION} VERSION_GREATER 3.6.0)
   message(FATAL_ERROR "Double-down requires Embree v3.6.1 or higher.")
 endif()
+
+# set embree version
 
 # Set install locations
 set( DD_BINARY_INSTALL_LOCATION "${CMAKE_INSTALL_PREFIX}/tools" )
@@ -57,10 +64,17 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # add library
-add_library( dd SHARED "src/RTI.cpp" "src/primitives.cpp" "src/MOABRay.cpp" "src/MOABDirectAccess.cpp")
+add_library(dd SHARED "src/RTI.cpp" "src/primitives.cpp" "src/MOABRay.cpp" "src/MOABDirectAccess.cpp")
 target_include_directories(dd PRIVATE ${CMAKE_SOURCE_DIR}/include)
 set_target_properties(dd PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 set_target_properties(dd PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib )
+
+# pass precompile definition depending on embree version
+if (${EMBREE_VERSION} VERSION_GREATER_EQUAL 4.0.0)
+  target_compile_definitions(dd PUBLIC EMBREE4)
+else()
+  target_compile_definitions(dd PUBLIC EMBREE3)
+endif()
 
 target_include_directories( dd INTERFACE "${CMAKE_INSTALL_PREFIX}/include" ${EMBREE_INCLUDE_DIRS})
 target_link_libraries( dd ${MOAB_LIBRARIES} ${EMBREE_LIBRARY} )

--- a/ci/embree-install.sh
+++ b/ci/embree-install.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Embree Variables
-EMBREE_TAG='v3.6.1'
+EMBREE_TAG='v${1}'
 EMBREE_REPO='https://github.com/embree/embree'
 EMBREE_INSTALL_DIR=$HOME/EMBREE/
 

--- a/ci/embree-install.sh
+++ b/ci/embree-install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 
-# Embree Variables
-EMBREE_TAG='v${1}'
+# Embree Variables -- use first argument to script as version number
+EMBREE_TAG="v${1}"
 EMBREE_REPO='https://github.com/embree/embree'
 EMBREE_INSTALL_DIR=$HOME/EMBREE/
 

--- a/include/double-down/MOABRay.h
+++ b/include/double-down/MOABRay.h
@@ -1,14 +1,13 @@
 #ifndef DD_RAY_FUNCS_H
 #define DD_RAY_FUNCS_H
 
-// Embree
-#include "embree3/rtcore.h"
-
 // MOAB
 #include "moab/GeomQueryTool.hpp"
 
 // Double-down
 #include "ray.h"
+
+#include "double-down/embree_interface.hpp"
 
 using namespace double_down;
 

--- a/include/double-down/RTI.hpp
+++ b/include/double-down/RTI.hpp
@@ -1,8 +1,8 @@
 #ifndef DD_RTI_H
 #define DD_RTI_H
 
-#include "embree3/rtcore.h"
-#include "embree3/rtcore_ray.h"
+#include <unordered_map>
+#include <memory>
 
 #include "moab/Core.hpp"
 #include "moab/GeomQueryTool.hpp"
@@ -12,8 +12,8 @@
 #include "MOABRay.h"
 #include "MOABDirectAccess.h"
 
-#include <unordered_map>
-#include <memory>
+#include "embree_interface.hpp"
+
 
 namespace double_down {
 

--- a/include/double-down/embree3.hpp
+++ b/include/double-down/embree3.hpp
@@ -1,0 +1,17 @@
+
+#include "embree3/rtcore.h"
+
+#ifndef DD_EMBREE_WRAPPERS
+#define DD_EMBREE_WRAPPERS
+
+// provide a function signature that matches the one in embree > v4.
+// the context is created internally
+inline void rtcIntersect1(RTCScene scene, RTCRayHit* rayhit) {
+  {
+    RTCIntersectContext context;
+    rtcInitIntersectContext(&context);
+    rtcIntersect1(scene, &context, rayhit);
+  }
+}
+
+#endif // include guard

--- a/include/double-down/embree4.hpp
+++ b/include/double-down/embree4.hpp
@@ -1,0 +1,3 @@
+
+#include "embree4/rtcore.h"
+#include "embree4/rtcore_ray.h"

--- a/include/double-down/embree_interface.hpp
+++ b/include/double-down/embree_interface.hpp
@@ -1,0 +1,14 @@
+
+#ifdef EMBREE4
+
+#include "double-down/embree4.hpp"
+
+#elif defined(EMBREE3)
+
+#include "double-down/embree3.hpp"
+
+#else
+
+#error "No embree version provided to compiler"
+
+#endif

--- a/include/double-down/primitives.hpp
+++ b/include/double-down/primitives.hpp
@@ -4,8 +4,6 @@
 
 #include <array>
 
-// Embree
-#include "embree3/rtcore.h"
 
 // MOAB
 #include "moab/Core.hpp"
@@ -15,6 +13,8 @@
 #include "ray.h"
 #include "MOABDirectAccess.h"
 
+// Embree
+#include "double-down/embree_interface.hpp"
 namespace double_down {
 
 /*! Structure with triangle information used in Embree */

--- a/include/double-down/ray.h
+++ b/include/double-down/ray.h
@@ -2,11 +2,10 @@
 #ifndef DD_RAY_H
 #define DD_RAY_H
 
-// Embree
-#include "embree3/rtcore_ray.h"
-
 // Double-down
 #include "Vec3da.h"
+
+#include "double-down/embree_interface.hpp"
 
 namespace double_down {
 

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -8,8 +8,6 @@
 // Double-down
 #include "double-down/RTI.hpp"
 #include "double-down/constants.h"
-#include "double-down/embree_wrapper.hpp"
-
 
 namespace double_down {
 

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -8,6 +8,7 @@
 // Double-down
 #include "double-down/RTI.hpp"
 #include "double-down/constants.h"
+#include "double-down/embree_wrapper.hpp"
 
 
 namespace double_down {
@@ -584,9 +585,7 @@ void RayTracingInterface::shutdown() {
 void RayTracingInterface::fire(moab::EntityHandle volume, RTCDRayHit &rayhit)
 {
   {
-    RTCIntersectContext context;
-    rtcInitIntersectContext(&context);
-    rtcIntersect1(scene_map[volume],&context,(RTCRayHit*)&rayhit);
+    rtcIntersect1(scene_map[volume], (RTCRayHit*)&rayhit);
     rayhit.hit.Ng_x = -rayhit.hit.Ng_x;
     rayhit.hit.Ng_y = -rayhit.hit.Ng_y;
     rayhit.hit.Ng_z = -rayhit.hit.Ng_z;
@@ -740,9 +739,7 @@ RayTracingInterface::point_in_volume(const moab::EntityHandle volume,
 
   // fire ray
   {
-   RTCIntersectContext context;
-    rtcInitIntersectContext(&context);
-    rtcIntersect1(scene,&context,(RTCRayHit*)&mbrayhit);
+    rtcIntersect1(scene,(RTCRayHit*)&mbrayhit);
     // triangle normal conventions are the flipped in Embree compared to MOAB
     // TODO: reverse the initial triangle normals so we don't have to do these ops here.
     mbhit.Ng_x = -mbhit.Ng_x;
@@ -890,9 +887,7 @@ RayTracingInterface::ray_fire(const moab::EntityHandle volume,
 
   // fire ray
   {
-    RTCIntersectContext context;
-    rtcInitIntersectContext(&context);
-    rtcIntersect1(scene,&context,(RTCRayHit*)&rayhit);
+    rtcIntersect1(scene, (RTCRayHit*)&rayhit);
     mbhit.Ng_x = -mbhit.Ng_x;
     mbhit.Ng_y = -mbhit.Ng_y;
     mbhit.Ng_z = -mbhit.Ng_z;
@@ -917,9 +912,7 @@ RayTracingInterface::ray_fire(const moab::EntityHandle volume,
 
   // fire ray in negative direction
   if (overlap_thickness > 0.0) {
-    RTCIntersectContext context;
-    rtcInitIntersectContext(&context);
-    rtcIntersect1(scene,&context,(RTCRayHit*)&neg_ray);
+    rtcIntersect1(scene,(RTCRayHit*)&neg_ray);
     neg_hit.Ng_x = -neg_hit.Ng_x;
     neg_hit.Ng_y = -neg_hit.Ng_y;
     neg_hit.Ng_z = -neg_hit.Ng_z;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_executable(test_mb test_mb.cpp test_utils.cpp)
 target_include_directories(test_mb PUBLIC ${MOAB_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include/)
-target_link_libraries(test_mb ${MOAB_LIBRARIES})
+target_link_libraries(test_mb ${MOAB_LIBRARIES} dd)
 set_target_properties(test_mb PROPERTIES BUILD_RPATH "${MOAB_LIBRARY_DIRS}")
 set_target_properties(test_mb PROPERTIES BUILD_RPATH_USE_LINK_PATH TRUE)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,7 +2,6 @@
 add_executable(ray_fire ray_fire.cpp)
 target_include_directories(ray_fire PUBLIC ${MOAB_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include/)
 target_link_libraries(ray_fire ${MOAB_LIBRARIES} ${EMBREE_LIBRARY} dd)
-target_link_libraries(ray_fire ${EMBREE_LIBRARY})
 install(TARGETS ray_fire DESTINATION ${DD_BINARY_INSTALL_LOCATION})
 
 add_executable(closest_to_location closest_to_location.cpp)


### PR DESCRIPTION
[Embree 4.0](https://github.com/embree/embree/releases/tag/v4.0.0) was released earlier this year and includes some minor API changes for the `rtcIntersect*` functions. Namely, it removes the required `RTCContext` argument and replaces it with an optional pointer to a `RTCRayQueryContext` structure. 

This PR insulates double-down from this change via an interface header that will include wrapped (or replaced) functions in either an `embree3.hpp` or `embree4.hpp` header. A hypothetical `embree5.hpp` file can easily be added in the future and keeps invasive changes out of the double down source viles.

Testing for Embree v4 has been added to CI as well.

@ebknudsen would you mind taking a look at this when you have time?