### PR TITLE
add missing install statements for embree interface headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,9 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/double-down/sys.h" DESTINATIO
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/double-down/Vec3fa.h" DESTINATION "${DD_INCLUDE_INSTALL_LOCATION}")
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/double-down/Vec3ba.h" DESTINATION "${DD_INCLUDE_INSTALL_LOCATION}")
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/double-down/Vec3.h" DESTINATION "${DD_INCLUDE_INSTALL_LOCATION}")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/double-down/embree3.hpp" DESTINATION "${DD_INCLUDE_INSTALL_LOCATION}")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/double-down/embree4.hpp" DESTINATION "${DD_INCLUDE_INSTALL_LOCATION}")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/double-down/embree_interface.hpp" DESTINATION "${DD_INCLUDE_INSTALL_LOCATION}")
 
 # Tests
 enable_testing()


### PR DESCRIPTION
The new embree interface headers that enable support for _both_ embree 3 and 4 were not installed (#37). This PR fixes this.
Possibly we should only install embree3/4 as needed instead of both. 