### PR TITLE
add functions to expose moabs find_volume

### DIFF
--- a/include/double_down/RTI.hpp
+++ b/include/double_down/RTI.hpp
@@ -138,7 +138,7 @@ class RayTracingInterface {
   //! \param uwv optional direction vector to be consistent across calls.
   moab::ErrorCode find_volume(const double xyz[3],
                                        moab::EntityHandle &volume,
-                                       const double &uwv = NULL);
+                                       const double *uwv = NULL);
 
   //! \brief Calculates the solid angle of a polygon, \p face, with respect to \p point.
   //! This method is adapted from "Point in Polyhedron Testing Using Spherical Polygons", Paulo Cezar

--- a/include/double_down/RTI.hpp
+++ b/include/double_down/RTI.hpp
@@ -138,7 +138,7 @@ class RayTracingInterface {
   //! \param uwv optional direction vector to be consistent across calls.
   moab::ErrorCode find_volume(const double xyz[3],
                                        moab::EntityHandle &volume,
-                                       const double *uwv = NULL);
+                                       const double *uvw = NULL);
 
   //! \brief Calculates the solid angle of a polygon, \p face, with respect to \p point.
   //! This method is adapted from "Point in Polyhedron Testing Using Spherical Polygons", Paulo Cezar

--- a/include/double_down/RTI.hpp
+++ b/include/double_down/RTI.hpp
@@ -130,6 +130,16 @@ class RayTracingInterface {
                                        const double xyz[3],
                                        int& result);
 
+
+  //! \brief Point containment query for the specified point \p xyz and using acceleration features
+  //! of MOAB.
+  //! \param xyz The point to check.
+  //! \param volume MOAB entity to check against.
+  //! \param uwv optional direction vector to be consistent across calls.
+  moab::ErrorCode find_volume(const double xyz[3],
+                                       moab::EntityHandle &volume,
+                                       const double &uwv = NULL);
+
   //! \brief Calculates the solid angle of a polygon, \p face, with respect to \p point.
   //! This method is adapted from "Point in Polyhedron Testing Using Spherical Polygons", Paulo Cezar
   //! Pinto Carvalho and Paulo Roma Cavalcanti, _Graphics Gems V_, pg. 42.  Original algorithm

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -763,7 +763,7 @@ RayTracingInterface::point_in_volume(const moab::EntityHandle volume,
 moab::ErrorCode
 RayTracingInterface::find_volume(const double xyz[3],
                                    moab::EntityHandle &volume,
-                                   const double *uvw = NULL)
+                                   const double *uvw)
 {
   moab::ErrorCode rval;
   rval = moab::find_volume(xyz,volume,uvw);

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -763,7 +763,7 @@ RayTracingInterface::point_in_volume(const moab::EntityHandle volume,
 moab::ErrorCode
 RayTracingInterface::find_volume(const double xyz[3],
                                    moab::EntityHandle &volume,
-                                   const double &uwv = NULL)
+                                   const double *uwv = NULL)
 {
   moab::ErrorCode rval;
   rval = moab::find_volume(xyz,volume,uvw);

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -760,6 +760,16 @@ RayTracingInterface::point_in_volume(const moab::EntityHandle volume,
   return moab::MB_SUCCESS;
 }
 
+moab::ErrorCode
+RayTracingInterface::find_volume(const double xyz[3],
+                                   moab::EntityHandle &volume,
+                                   const double &uwv = NULL)
+{
+  moab::ErrorCode rval;
+  rval = moab::find_volume(xyz,volume,uvw);
+  return rval;
+}
+
 void
 RayTracingInterface::boundary_case(moab::EntityHandle volume,
                                    int& result,

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -4,6 +4,7 @@
 // MOAB
 #include "MBTagConventions.hpp"
 #include "moab/GeomTopoTool.hpp"
+#include "moab/GeomQueryTool.hpp"
 
 // Double-down
 #include "double_down/RTI.hpp"
@@ -766,7 +767,8 @@ RayTracingInterface::find_volume(const double xyz[3],
                                    const double *uvw)
 {
   moab::ErrorCode rval;
-  rval = moab::find_volume(xyz,volume,uvw);
+  auto gqt = std::shared_ptr<moab::GeomQueryTool> ( new moab::GeomQueryTool(this->gttool()) );
+  rval = gqt->find_volume(xyz,volume,uvw);
   return rval;
 }
 

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -763,7 +763,7 @@ RayTracingInterface::point_in_volume(const moab::EntityHandle volume,
 moab::ErrorCode
 RayTracingInterface::find_volume(const double xyz[3],
                                    moab::EntityHandle &volume,
-                                   const double *uwv = NULL)
+                                   const double *uvw = NULL)
 {
   moab::ErrorCode rval;
   rval = moab::find_volume(xyz,volume,uvw);


### PR DESCRIPTION
This PR adds a function header for passing calls through to moab's find_volume-function.
As an additional upshot it will not trip DAGMC-compilation since it is now exposing this moab function and expects it to be present also in the double-down interface.

potential fix for #40