### PR TITLE
Updating apt packages before installing packages

### DIFF
--- a/ci/install-apt-pkgs.sh
+++ b/ci/install-apt-pkgs.sh
@@ -1,5 +1,5 @@
 set -ex
-
+apt update
 apt install -y \
     mpich \
     libmpich-dev \


### PR DESCRIPTION
[This is an issue](https://github.com/actions/runner-images/issues/5470) from a while back, but the failures in https://github.com/pshriwise/double-down/actions/runs/7133715929 seem to be the same.