### PR TITLE
Allow non x86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -march=native -mavx2")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -march=native -mavx2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -march=native")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -march=native")
 
 IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64") # for desktop
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -march=native -mavx2")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -march=native -mavx2")
 
+IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64") # for desktop
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mavx2")
+ENDIF()
+
 # MOAB
 find_package(MOAB REQUIRED HINTS ${MOAB_DIR})
 MESSAGE ( STATUS "Found MOAB Version: " ${MOAB_VERSION} )

--- a/include/double_down/Vec3da.h
+++ b/include/double_down/Vec3da.h
@@ -5,8 +5,10 @@
 #include <assert.h>
 #include <iostream>
 #include <math.h>
-#include <immintrin.h>
-#include <xmmintrin.h>
+#if defined(__x86_64__)
+  #include <immintrin.h>
+  #include <xmmintrin.h>
+#endif 
 #include <limits>
 
 #ifndef NDEBUG


### PR DESCRIPTION
Was trying to build on an ARM system (aarch64) and predictably avx2 doesn't exist on that instruction set. This change should allow compilation on all systems - should I find a nice set for ARM i'll add them