### PR TITLE
Updates to remove compiler warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,16 @@ jobs:
       shell: bash
       run: ls $HOME/dd
 
+
+
     # This test is here to check compatibility with DAGMC's develop branch
     # An error here shouldn't cause the build to fail
     - name: DAGMC Build and Test
       shell: bash
       run: $GITHUB_WORKSPACE/ci/dagmc-install.sh
+
+    - name: Debug with tmate if failure
+      if: failure()
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -march=native")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -march=native")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -march=native -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -march=native -Wall")
 
 IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64") # for desktop
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")

--- a/ci/moab-install.sh
+++ b/ci/moab-install.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # MOAB Variables
-MOAB_BRANCH='master'
+MOAB_BRANCH='5.4.1'
 MOAB_REPO='https://bitbucket.org/fathomteam/moab/'
 MOAB_INSTALL_DIR=$HOME/MOAB/
 

--- a/include/double_down/MOABDirectAccess.h
+++ b/include/double_down/MOABDirectAccess.h
@@ -33,7 +33,7 @@ public:
   //! \brief Check that a triangle is part of the managed coordinates here
   inline bool accessible(EntityHandle tri) {
     // determine the correct index to use
-    int idx = 0;
+    size_t idx = 0;
     auto fe = first_elements_[idx];
     while(true) {
       if (tri - fe.first < fe.second) { break; }

--- a/include/double_down/constants.h
+++ b/include/double_down/constants.h
@@ -9,75 +9,62 @@ namespace double_down {
 static const float min_rcp_input = std::numeric_limits<float>::min() /* FIX ME */ *1E5 /* SHOULDNT NEED TO MULTIPLY BY THIS VALUE */;
 static const int BVH_MAX_DEPTH = 64;
 
-/* we consider floating point numbers in that range as valid input numbers */
-static float FLT_LARGE = 1.844E18f;
-
-static struct UlpTy
+struct NegInfTy
 {
-  inline operator double( ) const { return std::numeric_limits<double>::epsilon(); }
-  inline operator float ( ) const { return std::numeric_limits<float>::epsilon(); }
-} ulp;
+  constexpr operator          double   ( ) const { return -std::numeric_limits<double>::infinity(); }
+  constexpr operator          float    ( ) const { return -std::numeric_limits<float>::infinity(); }
+  constexpr operator          long long( ) const { return std::numeric_limits<long long>::min(); }
+  constexpr operator unsigned long long( ) const { return std::numeric_limits<unsigned long long>::min(); }
+  constexpr operator          long     ( ) const { return std::numeric_limits<long>::min(); }
+  constexpr operator unsigned long     ( ) const { return std::numeric_limits<unsigned long>::min(); }
+  constexpr operator          int      ( ) const { return std::numeric_limits<int>::min(); }
+  constexpr operator unsigned int      ( ) const { return std::numeric_limits<unsigned int>::min(); }
+  constexpr operator          short    ( ) const { return std::numeric_limits<short>::min(); }
+  constexpr operator unsigned short    ( ) const { return std::numeric_limits<unsigned short>::min(); }
+  constexpr operator          char     ( ) const { return std::numeric_limits<char>::min(); }
+  constexpr operator unsigned char     ( ) const { return std::numeric_limits<unsigned char>::min(); }
 
-static struct NegInfTy
+};
+constexpr NegInfTy neg_inf;
+
+struct EmptyTy {
+};
+constexpr EmptyTy empty;
+
+struct PosInfTy
 {
-  inline operator          double   ( ) const { return -std::numeric_limits<double>::infinity(); }
-  inline operator          float    ( ) const { return -std::numeric_limits<float>::infinity(); }
-  inline operator          long long( ) const { return std::numeric_limits<long long>::min(); }
-  inline operator unsigned long long( ) const { return std::numeric_limits<unsigned long long>::min(); }
-  inline operator          long     ( ) const { return std::numeric_limits<long>::min(); }
-  inline operator unsigned long     ( ) const { return std::numeric_limits<unsigned long>::min(); }
-  inline operator          int      ( ) const { return std::numeric_limits<int>::min(); }
-  inline operator unsigned int      ( ) const { return std::numeric_limits<unsigned int>::min(); }
-  inline operator          short    ( ) const { return std::numeric_limits<short>::min(); }
-  inline operator unsigned short    ( ) const { return std::numeric_limits<unsigned short>::min(); }
-  inline operator          char     ( ) const { return std::numeric_limits<char>::min(); }
-  inline operator unsigned char     ( ) const { return std::numeric_limits<unsigned char>::min(); }
+  constexpr operator          double   ( ) const { return std::numeric_limits<double>::infinity(); }
+  constexpr operator          float    ( ) const { return std::numeric_limits<float>::infinity(); }
+  constexpr operator          long long( ) const { return std::numeric_limits<long long>::max(); }
+  constexpr operator unsigned long long( ) const { return std::numeric_limits<unsigned long long>::max(); }
+  constexpr operator          long     ( ) const { return std::numeric_limits<long>::max(); }
+  constexpr operator unsigned long     ( ) const { return std::numeric_limits<unsigned long>::max(); }
+  constexpr operator          int      ( ) const { return std::numeric_limits<int>::max(); }
+  constexpr operator unsigned int      ( ) const { return std::numeric_limits<unsigned int>::max(); }
+  constexpr operator          short    ( ) const { return std::numeric_limits<short>::max(); }
+  constexpr operator unsigned short    ( ) const { return std::numeric_limits<unsigned short>::max(); }
+  constexpr operator          char     ( ) const { return std::numeric_limits<char>::max(); }
+  constexpr operator unsigned char     ( ) const { return std::numeric_limits<unsigned char>::max(); }
+};
+constexpr PosInfTy inf;
 
-} neg_inf;
 
-static struct EmptyTy {
-} empty;
-
-static struct PosInfTy
+struct ZeroTy
 {
-  inline operator          double   ( ) const { return std::numeric_limits<double>::infinity(); }
-  inline operator          float    ( ) const { return std::numeric_limits<float>::infinity(); }
-  inline operator          long long( ) const { return std::numeric_limits<long long>::max(); }
-  inline operator unsigned long long( ) const { return std::numeric_limits<unsigned long long>::max(); }
-  inline operator          long     ( ) const { return std::numeric_limits<long>::max(); }
-  inline operator unsigned long     ( ) const { return std::numeric_limits<unsigned long>::max(); }
-  inline operator          int      ( ) const { return std::numeric_limits<int>::max(); }
-  inline operator unsigned int      ( ) const { return std::numeric_limits<unsigned int>::max(); }
-  inline operator          short    ( ) const { return std::numeric_limits<short>::max(); }
-  inline operator unsigned short    ( ) const { return std::numeric_limits<unsigned short>::max(); }
-  inline operator          char     ( ) const { return std::numeric_limits<char>::max(); }
-  inline operator unsigned char     ( ) const { return std::numeric_limits<unsigned char>::max(); }
-} inf;
-
-
-static struct ZeroTy
-{
-  inline operator          double   ( ) const { return 0; }
-  inline operator          float    ( ) const { return 0; }
-  inline operator          long long( ) const { return 0; }
-  inline operator unsigned long long( ) const { return 0; }
-  inline operator          long     ( ) const { return 0; }
-  inline operator unsigned long     ( ) const { return 0; }
-  inline operator          int      ( ) const { return 0; }
-  inline operator unsigned int      ( ) const { return 0; }
-  inline operator          short    ( ) const { return 0; }
-  inline operator unsigned short    ( ) const { return 0; }
-  inline operator          char     ( ) const { return 0; }
-  inline operator unsigned char     ( ) const { return 0; }
-} zero;
-
-static struct TrueTy {
-  inline operator bool( ) const { return true; }
-} True;
-
-static struct FalseTy {
-  inline operator bool( ) const { return false; }
-} False;
+  constexpr operator          double   ( ) const { return 0; }
+  constexpr operator          float    ( ) const { return 0; }
+  constexpr operator          long long( ) const { return 0; }
+  constexpr operator unsigned long long( ) const { return 0; }
+  constexpr operator          long     ( ) const { return 0; }
+  constexpr operator unsigned long     ( ) const { return 0; }
+  constexpr operator          int      ( ) const { return 0; }
+  constexpr operator unsigned int      ( ) const { return 0; }
+  constexpr operator          short    ( ) const { return 0; }
+  constexpr operator unsigned short    ( ) const { return 0; }
+  constexpr operator          char     ( ) const { return 0; }
+  constexpr operator unsigned char     ( ) const { return 0; }
+};
+constexpr ZeroTy zero;
 
 } // end namespace double_down
 

--- a/src/RTI.cpp
+++ b/src/RTI.cpp
@@ -19,7 +19,7 @@ void error(void* dum, RTCError code, const char* str) {
   }
 }
 
-RayTracingInterface::RayTracingInterface(moab::Interface *mbi) : GTT(std::make_shared<moab::GeomTopoTool>(mbi)), MBI(mbi) {}
+RayTracingInterface::RayTracingInterface(moab::Interface *mbi) :MBI(mbi), GTT(std::make_shared<moab::GeomTopoTool>(mbi)) {}
 
 RayTracingInterface::RayTracingInterface(std::shared_ptr<moab::GeomTopoTool> gtt) : MBI(gtt->get_moab_instance()), GTT(gtt) {}
 
@@ -337,10 +337,6 @@ void RayTracingInterface::deleteBVH(moab::EntityHandle volume)
     "BVHs can only be created and deleted by volume in double-down.");
     return;
   }
-
-  int ent_dim = GTT->dimension(volume);
-  moab::Range surfs;
-
   // remove the scene from Embree
   rtcReleaseScene(scene_map[volume]);
 
@@ -551,9 +547,6 @@ void RayTracingInterface::closest(moab::EntityHandle volume,
                                   moab::EntityHandle* surface,
                                   moab::EntityHandle* facet)
 {
-
-  const std::vector<DblTri>& buffer = buffer_storage.retrieve_buffer(volume);
-
   // create point query object, a dual representation of the single and double precision query,
   // sets parameters of the closest to location query
   RTCDPointQuery point_query;
@@ -586,8 +579,8 @@ void RayTracingInterface::closest(moab::EntityHandle volume,
   RTCGeometry g = rtcGetGeometry(scene, point_query.geomID);
   // look up the triangle buffer array we stored on this geometry
   const UserData* user_data = (const UserData*) rtcGetGeometryUserData(g);
-  // find the DblTri in the array using the primitive ID as an index
   const DblTri* tris = (const DblTri*) user_data->tri_ptr;
+  // find the DblTri in the array using the primitive ID as an index
   const DblTri& this_tri = tris[point_query.primID];
 
   // set the outgoing surface and triangle data
@@ -912,8 +905,6 @@ RayTracingInterface::test_volume_boundary(const moab::EntityHandle volume,
                                           int& result,
                                           const moab::GeomQueryTool::RayHistory* history)
 {
-  moab::ErrorCode rval;
-
   int dir;
   moab::EntityHandle last_facet_hit = 0;
   if (history) { history->get_last_intersection(last_facet_hit); }

--- a/src/primitives.cpp
+++ b/src/primitives.cpp
@@ -17,6 +17,8 @@ void intersectionFilter(void* ptr, RTCDRayHit &rayhit)
       if (0 > rayhit.dot_prod()) { rayhit.hit.geomID = RTC_INVALID_GEOMETRY_ID; }
       break;
     case RayFireType::PIV: //if this is a point_in_vol fire, accept all hits
+    case RayFireType::ACCUM: //if this is an accumulation fire, accept all hits
+    case RayFireType::FV: //if this is a fire for finding a volume, accept all hits
       break;
     }
 }
@@ -111,7 +113,7 @@ void DblTriOccludedFunc(RTCOccludedFunctionNArguments* args) {
   // get the double precision ray from the args
   RTCDRay* ray = (RTCDRay*)&(args->ray);
 
-  MBDirectAccess* mdam = (MBDirectAccess*) mdam;
+  MBDirectAccess* mdam = (MBDirectAccess*) this_tri.mdam;
 
   std::array<moab::CartVect, 3> coords = mdam->get_mb_coords(this_tri.handle);
 

--- a/test/test_closest.cpp
+++ b/test/test_closest.cpp
@@ -31,8 +31,6 @@ int main() {
 
   // fire a test ray
   double org[3] = {0.0, 0.0, 0.0};
-  double dir[3] = {1.0, 0.0, 0.0};
-
   double dist = 0.0;
 
   std::cout << "Running closest test" << std::endl;

--- a/tools/ray_fire.cpp
+++ b/tools/ray_fire.cpp
@@ -30,8 +30,6 @@ int main(int argc, char** argv) {
 
   po.parseCommandLine(argc, argv);
 
-
-
   std::shared_ptr<RayTracingInterface> RTI{new RayTracingInterface()};
 
   std::cout << "Double Down Git SHA: " << RTI->git_sha() << std::endl;
@@ -39,7 +37,6 @@ int main(int argc, char** argv) {
 #ifdef __AVX2__
   std::cout << "AVX2 Enabled" << std::endl;
 #endif
-
 
   moab::ErrorCode rval;
   rval = RTI->load_file(filename);
@@ -83,7 +80,7 @@ int main(int argc, char** argv) {
     total += std::clock() - mark;
 
    // make sure we hit something
-    if (rayhit.hit.geomID == -1) {
+    if (rayhit.hit.geomID < 0) {
       std::cout << "Miss!" << std::endl;
       exit(1);
     }


### PR DESCRIPTION
Some downstream packages that are using double-down include additional compiler flags that identify compiler warnings as errors. This PR updates double-down to remove such compiler warnings and adds the `-Wall` flag to C++ compilation in CMake so these are more apparent going forward.