### PR TITLE
MNT: Use policy_max in cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...4.2)
 project( DBLDOWN )
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
* Set policy_max which defines the maximum CMake policy. cmake_minimum_required sets two minimums: the real (lower) minimum and the (upper) minimum based on has been tested with. The defaults (CMake policies) will be set to the highest value possible between the two values.
   - c.f. https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

Relevant for:
* https://github.com/conda-forge/dagmc-feedstock/issues/37
* https://github.com/pshriwise/double-down/issues/31
* https://github.com/conda-forge/staged-recipes/pull/32181

---

Example Pixi manifest that will build the project using the state of this PR:

```toml
[workspace]
channels = ["conda-forge"]
name = "double-down"
platforms = ["linux-64", "osx-arm64"]
version = "0.1.0"

[tasks.build]
cmd = """
rm -rf ./build && \
cmake $CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -S . -B build && \
cmake build -LH && \
cmake --build build --clean-first --parallel "$(nproc -- ignore=2)" && \
ctest --test-dir build --output-on-failure && \
cmake --install build
"""

[dependencies]
cxx-compiler = ">=1.11.0,<2"
cmake = ">=4.2.3,<5"
make = ">=4.4.1,<5"
moab = ">=5.6.0,<6"
embree = ">=4.4.0,<5"
eigen = ">=3.4.0,<4"
``` 

```console
$ pixi run build
```