### PR TITLE
Force 32-byte alignment of Vec3da so point_in_volume is correct without -mavx2

### DIFF
--- a/include/double_down/Vec3da.h
+++ b/include/double_down/Vec3da.h
@@ -21,7 +21,7 @@
 
 namespace double_down {
 
-struct Vec3da {
+struct alignas(32) Vec3da {
   typedef double Scalar;
   enum { n = 3 };
   union{


### PR DESCRIPTION
Fixes #53.

## Problem

`Vec3da`'s union only includes the `__m256` member — and therefore is only
forced to 32-byte alignment — when `__AVX2__` is defined:

```cpp
struct Vec3da {
  union {
#ifdef __AVX2__
    __m256 v;
#endif
    struct { double x, y, z; size_t a; };
  };
  ...
```

When double-down is compiled **without `-mavx2`** (e.g. portable manylinux
wheels that strip `-march=native -mavx2` so `libdd` doesn't bake in AVX-512/AVX2
and `SIGILL` on other CPUs), `Vec3da` drops to 8-byte alignment. That
under-alignment makes `RayTracingInterface::point_in_volume()` return incorrect
containment — points inside a volume report as *outside*.

Downstream this **silently breaks DAGMC geometry/slice plotting in OpenMC**
(every pixel comes back void), while Monte Carlo transport — driven by
`ray_fire`/surface-crossing rather than fresh `point_in_volume` queries — keeps
working, so it's easy to miss.

## Fix

Force 32-byte alignment of `Vec3da` unconditionally:

```cpp
struct alignas(32) Vec3da { ... };
```

This is a pure alignment directive — **no AVX instructions are emitted** — so it
is correct on CPUs with or without AVX2 and keeps portable (baseline x86-64)
builds working.

## Verification

Built double-down `develop` + this change with `-march=native -mavx2` stripped
(baseline x86-64), linked into DAGMC 3.2.4 + OpenMC. OpenMC's `Model.slice_data`
on a DAGMC model now returns correct cell/material IDs across the slice; with the
unpatched header the same build returns all-void. MC transport is unchanged in
both cases. Reproduced on the single-material DAGMC model from
neutronics-workshop `task_20` and on a multi-volume stellarator model.
